### PR TITLE
Adding awaits to update sheet info

### DIFF
--- a/src/app/shared/services/spreadsheet.service.ts
+++ b/src/app/shared/services/spreadsheet.service.ts
@@ -83,8 +83,8 @@ export class SpreadsheetService {
 
     public async getSpreadsheetData(spreadsheet: ISpreadsheet) : Promise<ISheet>{
         let data = await this._gigLoggerService.getSheetData(spreadsheet.id);
-        this.updateSheetName(spreadsheet.id, data);
-        this.updateSheetSize(spreadsheet.id, data);
+        await this.updateSheetName(spreadsheet.id, data);
+        await this.updateSheetSize(spreadsheet.id, data);
         return <ISheet>data;
     }
 


### PR DESCRIPTION
This PR updates the SpreadsheetService to correctly await asynchronous update functions before returning the sheet data.

- Converted updateSheetName and updateSheetSize calls to use await, ensuring that the updates complete before proceeding.