### PR TITLE
Remove isGoogleAllowed check from getGooglePredictions

### DIFF
--- a/src/app/shared/inputs/search-input/search-input.component.ts
+++ b/src/app/shared/inputs/search-input/search-input.component.ts
@@ -459,7 +459,7 @@ export class SearchInputComponent implements OnDestroy {
   // #endregion
 
   private async getGooglePredictions(value: string): Promise<ISearchItem[]> {
-    if (!this.isGoogleAllowed() || !this.googleSearch) {
+    if (!this.googleSearch) {
       return [];
     }
 


### PR DESCRIPTION
The method getGooglePredictions now only checks for the presence of googleSearch before proceeding, removing the isGoogleAllowed condition. This simplifies the logic for fetching Google predictions.